### PR TITLE
Set default hosts file in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = hosts


### PR DESCRIPTION
If you're cd'd into the project root, you won't have to pass the -i
flag anymore.