### PR TITLE
keep wp-content uploads accessible

### DIFF
--- a/roles/nginx_configs/files/sites-enabled/zeusweb.conf
+++ b/roles/nginx_configs/files/sites-enabled/zeusweb.conf
@@ -282,6 +282,11 @@ server {
             include fastcgi_params;
         }
     }
+    
+    location ~ /wp-content/uploads(/.*|$) {
+        root /home/zeusweb/public/wp-content/uploads/;
+        try_files $1 404.html;
+    }
 
     ####################
     # PHPMYADMIN


### PR DESCRIPTION
For the old blogposts on the new site the `wp-content/uploads` folder should be accessible.
- [ ] test
