### PR TITLE
Hydra cors

### DIFF
--- a/roles/nginx_sites_king/files/sites-enabled/hydra.conf
+++ b/roles/nginx_sites_king/files/sites-enabled/hydra.conf
@@ -17,6 +17,7 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/hydra.ugent.be/privkey.pem;
 
     location /api {
+		add_header 'Access-Control-Allow-Origin' '*';
         alias /home/hydra/public/api/;
         autoindex on;
     }

--- a/roles/nginx_sites_king/files/sites-enabled/hydra.conf
+++ b/roles/nginx_sites_king/files/sites-enabled/hydra.conf
@@ -17,7 +17,7 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/hydra.ugent.be/privkey.pem;
 
     location /api {
-		add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Origin' '*';
         alias /home/hydra/public/api/;
         autoindex on;
     }


### PR DESCRIPTION
Adds a CORS header to the Hydra API. We allow everything, since it is a read-only public API.
See https://github.com/ZeusWPI/hydra/issues/186.