### PR TITLE
update lan redirect in zeus site

### DIFF
--- a/roles/nginx_sites_king/files/sites-enabled/zeus.gent.conf
+++ b/roles/nginx_sites_king/files/sites-enabled/zeus.gent.conf
@@ -60,7 +60,7 @@ server {
     }
 
     location /lan {
-        return 302 https://zeus.gent/events/18-19/lan/;
+        return 302 https://zeus.gent/events/19-20/lan/;
     }
 
     location /truien {


### PR DESCRIPTION
Updated redirect:
zeus.gent/lan now redirects to https://zeus.gent/events/19-20/lan/.