### PR TITLE
Fix cammie socket issue

### DIFF
--- a/host_files/dickens/nginx/kelder.zeus.ugent.be
+++ b/host_files/dickens/nginx/kelder.zeus.ugent.be
@@ -83,6 +83,8 @@ server {
     }
 
     location /socket.io/ {
+        add_header 'Access-Control-Allow-Origin' '*';
+
         proxy_redirect off;
         proxy_pass_request_headers on;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
The cammie page on the Zeus website wants to poll a socket to receive 'message replies'. It fails and this commit should fix it.

Error:
![image](https://user-images.githubusercontent.com/47608311/213325541-908a8188-970c-4bde-9aab-d9714d2d2972.png)
