### PR TITLE
Set asdf Ruby shim for tap.zeus.gent

### DIFF
--- a/host_files/herbert/nginx/tab.zeus.gent
+++ b/host_files/herbert/nginx/tab.zeus.gent
@@ -10,6 +10,8 @@ server {
 }
 
 server {
+    passenger_ruby /home/tab/.asdf/shims/ruby;
+
     listen 443 ssl http2;
     server_name tab.zeus.gent;
 

--- a/host_files/herbert/nginx/tap.zeus.gent
+++ b/host_files/herbert/nginx/tap.zeus.gent
@@ -10,6 +10,8 @@ server {
 }
 
 server {
+    passenger_ruby /home/tap/.asdf/shims/ruby;
+
     listen 443 ssl http2;
     server_name tap.zeus.gent;
     client_max_body_size 50M;


### PR DESCRIPTION
This _should_ work according to https://www.phusionpassenger.com/library/config/nginx/reference/#passenger_ruby