### PR TITLE
Un-passengerize Tap, point it to the Dockerized Tap

### DIFF
--- a/host_files/herbert/nginx/tap.zeus.gent
+++ b/host_files/herbert/nginx/tap.zeus.gent
@@ -1,3 +1,8 @@
+upstream tap {
+   server localhost:3008;
+   keepalive 32;
+}
+
 server {
     listen 80;
     server_name tap.zeus.gent;
@@ -12,24 +17,21 @@ server {
 server {
     listen 443 ssl http2;
     server_name tap.zeus.gent;
-    client_max_body_size 50M;
-
-    location / {
-        passenger_enabled on;
-        passenger_preload_bundler on;
-
-        alias /home/tap/production/current/public/;
-
-        passenger_base_uri /;
-        
-        passenger_app_root      /home/tap/production/current;
-        passenger_document_root /home/tap/production/current/public;
-    }
 
     ssl_certificate     /root/.acme.sh/*.zeus.gent/fullchain.cer;
     ssl_certificate_key /root/.acme.sh/*.zeus.gent/*.zeus.gent.key;
     include snippets/ssl_options_preload.conf;
 
-    access_log /home/tap/log/access.log;
-    error_log  /home/tap/log/error.log;
+   location / {
+       client_max_body_size 50M;
+       proxy_buffers 256 16k;
+       proxy_buffer_size 16k;
+       client_body_timeout 60;
+       send_timeout 300;
+       lingering_timeout 5;
+       proxy_connect_timeout 90;
+       proxy_send_timeout 300;
+       proxy_read_timeout 90s;
+       proxy_pass http://tap;
+   }
 }


### PR DESCRIPTION
2 disclaimers:

1) Untested
2) The dockerized version isn't running yet. MR in Tap: https://github.com/ZeusWPI/Tap/pull/202